### PR TITLE
Fixes Currency-Convert

### DIFF
--- a/BlazorChat/BlazorChat.csproj
+++ b/BlazorChat/BlazorChat.csproj
@@ -9,6 +9,7 @@
 		<PackageReference Include="Markdig" Version="0.37.0" />
 		<PackageReference Include="Microsoft.SemanticKernel" Version="1.20.0" />
 		<PackageReference Include="SimpleFeedReader" Version="1.0.9" />
+		<PackageReference Include="Swftx.CurrencyConverter" Version="2.0.0" />
 	</ItemGroup>
 	<ItemGroup>
 	  <Content Update="appsettings.Development.json">

--- a/BlazorChat/Components/Layout/NavBar.razor
+++ b/BlazorChat/Components/Layout/NavBar.razor
@@ -10,7 +10,7 @@
                     <a class="nav-link" href="chat">Chat</a>                    
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="stockquote">Stock Quote</a>
+                    <a class="nav-link" href="stockquote">Stock & Currency</a>
                 </li>
             </ul>
         </div>

--- a/BlazorChat/Components/Pages/Chat.razor.cs
+++ b/BlazorChat/Components/Pages/Chat.razor.cs
@@ -23,6 +23,7 @@ public partial class Chat
     protected StringBuilder responseToDisplay = new();
     protected string UserInput = string.Empty;
     protected OpenAIPromptExecutionSettings? settings;
+    protected MarkdownPipeline pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
 
     protected override void OnInitialized()
     {
@@ -55,7 +56,7 @@ public partial class Chat
         {
             tmpBuffer.Append(chunk);
         }
-        responseToDisplay.Append(Markdown.ToHtml(tmpBuffer.ToString()));
+        responseToDisplay.Append(Markdown.ToHtml(tmpBuffer.ToString(),pipeline));
         responseToDisplay.Append("\n<br/>");
         StateHasChanged();
 

--- a/BlazorChat/Components/Pages/StockPrice.razor
+++ b/BlazorChat/Components/Pages/StockPrice.razor
@@ -17,3 +17,23 @@
 <textarea class="form-control" rows="9" @bind=@UserInput />
 <br />
 <button type="button" class="btn btn-success" @onclick="OnSubmitClick">Submit</button>
+<br/>
+<p>You can request stock quotes by asking, &quot;Please get me the quote for MSFT&quot; or &quot;Please get me the stock price for IBM, C, JPM, and TSLA; please present the values in a tabular format.&quot;</p>
+<p>For currency conversions, you can ask, &quot;Please convert 200 USD to INR, ZAR, and SZL&quot;. You can also get the values in a table by asking, &quot;Convert 200 USD to INR, ZAR, and SZL and present it as a table&quot;.</p>
+<p>Certainly! Let&#39;s refine that text to make it clear and concise:</p>
+<ol>
+    <li>
+        <p>To request stock quotes:</p>
+        <ul>
+            <li>You can say, &quot;Please get me the quote for MSFT.&quot;</li>
+            <li>Or, if you want multiple stock prices in a tabular format, say, &quot;Please get me the stock price for IBM, C, JPM, and TSLA; please present the values in a tabular format.&quot;</li>
+        </ul>
+    </li>
+    <li>
+        <p>For currency conversions:</p>
+        <ul>
+            <li>You can ask, &quot;Please convert 200 USD to INR, ZAR, and SZL.&quot;</li>
+            <li>If you&#39;d like the values presented in a table, say, &quot;Convert 200 USD to INR, ZAR, and SZL and present it as a table.&quot;</li>
+        </ul>
+    </li>
+</ol>

--- a/BlazorChat/Components/Pages/StockPrice.razor.cs
+++ b/BlazorChat/Components/Pages/StockPrice.razor.cs
@@ -23,15 +23,21 @@ public partial class StockPrice
     protected StringBuilder responseToDisplay = new();
     protected string UserInput = string.Empty;
     protected OpenAIPromptExecutionSettings? settings;
+    protected MarkdownPipeline pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
+
 
     protected override void OnInitialized()
     {
         History.AddSystemMessage("You are a friendly and jovial assistant who is not shy about asking for clarification. " +
             " When the user requests you for the price for a Ticker you will get stock quote for the ticker."+
-            " Your response will be detailed and provide all information regarding the ticker's current quote.");
+            " Your response will be detailed and provide all information regarding the ticker's current quote." +
+            " If asked to convert currency you will identify the target currency, base currency, and amount to " +
+            " convert and perform conversion");
         settings = new()
         {
-            ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions
+            ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions,
+            Temperature = 0.2,
+            TopP = 0.4
         };
     }
     protected async Task OnSubmitClick()
@@ -49,7 +55,8 @@ public partial class StockPrice
         {
             tmpBuffer.Append(chunk);
         }
-        responseToDisplay.Append(Markdown.ToHtml(tmpBuffer.ToString()));
+
+        responseToDisplay.Append(Markdown.ToHtml(tmpBuffer.ToString(),pipeline));
         responseToDisplay.Append("\n<br/>");
         StateHasChanged();
 

--- a/BlazorChat/Program.cs
+++ b/BlazorChat/Program.cs
@@ -24,11 +24,7 @@ catch (ArgumentException ex)
     Console.WriteLine(ex.Message);
     throw;
 }
-builder.Services.AddScoped(sp => KernelPluginFactory.CreateFromType<NewsPlugin>(serviceProvider: sp));
-builder.Services.AddScoped(sp => KernelPluginFactory.CreateFromType<ArchivePlugin>(serviceProvider: sp));
-builder.Services.AddScoped(sp => KernelPluginFactory.CreateFromType<WeatherPlugin>(serviceProvider: sp));
-builder.Services.AddScoped(sp => KernelPluginFactory.CreateFromType<StockServicePlugin>(serviceProvider: sp));
-builder.Services.AddHttpClient();
+SetupDependency(builder);
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
@@ -48,3 +44,13 @@ app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode();
 
 app.Run();
+
+static void SetupDependency(WebApplicationBuilder builder)
+{
+    builder.Services.AddScoped(sp => KernelPluginFactory.CreateFromType<NewsPlugin>(serviceProvider: sp));
+    builder.Services.AddScoped(sp => KernelPluginFactory.CreateFromType<ArchivePlugin>(serviceProvider: sp));
+    builder.Services.AddScoped(sp => KernelPluginFactory.CreateFromType<WeatherPlugin>(serviceProvider: sp));
+    builder.Services.AddScoped(sp => KernelPluginFactory.CreateFromType<StockServicePlugin>(serviceProvider: sp));
+    builder.Services.AddScoped(sp => KernelPluginFactory.CreateFromType<CurrencyService>(serviceProvider: sp));
+    builder.Services.AddHttpClient();
+}

--- a/BlazorChat/Services/CurrencyService.cs
+++ b/BlazorChat/Services/CurrencyService.cs
@@ -1,0 +1,79 @@
+﻿using Microsoft.SemanticKernel;
+using Swftx.CurrencyConverter;
+using System.ComponentModel;
+using Swftx.CurrencyConverter.Models.Primitives;
+
+namespace BlazorChat.Services;
+
+public class CurrencyService(ILogger<CurrencyService> logger, HttpClient client, IConfiguration configuration)
+{
+    private readonly ILogger<CurrencyService> logger = logger;
+    private readonly HttpClient client = client;
+    private readonly IConfiguration configuration = configuration;
+    private readonly CurrecyCoverterClient ccc = new CurrecyCoverterClient(client);
+    private const string fxRateAPIURL = @"https://api.fxratesapi.com/latest?base={fromCurrency}&symbols={toCurrency}&amount={amount}&format=JSON&api_key%3D={apiKey}";
+
+    //[KernelFunction("convert_currency_value")]
+    //[Description("Convert an amount from one currency to another")]
+    //public async Task<string> ConvertAmount(Kernel kernel
+    //   , [Description("The amount to convert")] string amount
+    //   , [Description("The starting currency code")] string fromCurrency
+    //   , [Description("The target currency code")] string toCurrency)
+    //{
+    //    bool isAmountValid = decimal.TryParse(amount, out decimal amountValue);
+    //    if (!isAmountValid)
+    //    {
+    //        logger.LogInformation("Invalid amount value");
+    //        return "Invalid amount value";
+    //    }
+    //    if (string.IsNullOrEmpty(fromCurrency) || string.IsNullOrEmpty(toCurrency))
+    //    {
+    //        logger.LogInformation("Invalid currency value");
+    //        return "Invalid currency value";
+    //    }
+    //    Response<Swftx.CurrencyConverter.Models.CurrencyRates> conversionResult = await ccc.GetLatestRatesAsync(fromCurrency, new string[] { toCurrency });
+    //    if (conversionResult.IsFailure)
+    //    {
+    //        logger.LogInformation("Conversion failed");
+    //        return "Conversion failed";
+    //    }
+    //    decimal convertedValue = conversionResult.Value.Rates[toCurrency] * amountValue;
+    //    string returnMsg = $@"{amount} {fromCurrency} is equal to {convertedValue} {toCurrency}";
+    //    return returnMsg;
+    //}
+    //Better using FXRatesAPI Directly.
+    [KernelFunction("convert_currency_value")]
+    [Description("Convert an amount from one currency to another")]
+    public async Task<string> ConvertAmount(Kernel kernel
+        , [Description("The amount to convert")] string amount
+        , [Description("The starting currency code")] string fromCurrency
+        , [Description("Array of string of currency codes to convert to")] string[] toCurrency)
+    {
+        bool isAmountValid = decimal.TryParse(amount, out decimal amountValue);
+        if (!isAmountValid)
+        {
+            logger.LogInformation("Invalid amount value");
+            return "Invalid amount value";
+        }
+        if (string.IsNullOrEmpty(fromCurrency) || toCurrency.Length == 0)
+        {
+            logger.LogInformation("Invalid currency value");
+            return "Invalid currency value";
+        }
+        string combinedCountires = string.Join(",", toCurrency);
+        var urlToUse = new Uri(fxRateAPIURL
+            .Replace("{fromCurrency}", fromCurrency)
+            .Replace("{toCurrency}", combinedCountires)
+            .Replace("{amount}", amount)
+            .Replace("{apiKey}", configuration["FXRatesAPI"]));
+        var request = new HttpRequestMessage
+        {
+            Method = HttpMethod.Get,
+            RequestUri = urlToUse
+        };
+        using var response = await client.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+        var body = await response.Content.ReadAsStringAsync();
+        return body;
+    }    
+}

--- a/BlazorChat/appsettings.json
+++ b/BlazorChat/appsettings.json
@@ -13,5 +13,6 @@
   },
   "WeatherApiKey": "abcdefghijklmnopqrstuvwxyz1234",
   "FinnHub": "FinnHub-API_Key",
+  "FXRatesAPI": "FXRatesAPI",
   "AllowedHosts": "*"
 }

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Armed with newfound enthusiasm, I embarked on my own coding voyage. Armed with V
 
 3. **Stock Market Sorcery**: This is in alpha form; i.e., it gets the stock quotes and presents it well but needs improvement in presentation. (Note: US stocks only for now, but who knows what the future holds?)
 
+4. **Currency Conversion**: As this feature resembled stock quotes, I figured I’d implement it too.
+
 ## *The Road Ahead*
 
 But wait, there's more! My journey doesn't end here. The horizon beckons with promises of even greater feats:


### PR DESCRIPTION
A currency conversion feature has been implemented.

Markdown tables needed to be presented in Stock quotes. Fixed with adding:
```cs
protected MarkdownPipeline pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
```
The pipeline is added as a parameter while displaying the markdown generated by LLM.
```cs
responseToDisplay.Append(Markdown.ToHtml(tmpBuffer.ToString(),pipeline));
```